### PR TITLE
fix agenda bindings with "Enter" key in terminal

### DIFF
--- a/evil-org-agenda.el
+++ b/evil-org-agenda.el
@@ -62,9 +62,13 @@
 
     ;; open
     (kbd "<tab>") 'org-agenda-goto
+    (kbd "TAB") 'org-agenda-goto
     (kbd "<return>") 'org-agenda-switch-to
+    (kbd "RET") 'org-agenda-switch-to
     (kbd "S-<return>") 'org-agenda-goto
+    (kbd "S-RET") 'org-agenda-goto
     (kbd "M-<return>") 'org-agenda-recenter
+    (kbd "M-RET") 'org-agenda-recenter
 
     (kbd "SPC") 'org-agenda-show-and-scroll-up
     (kbd "<delete>") 'org-agenda-show-scroll-down


### PR DESCRIPTION
It's basically the same problem as hlissner/doom-emacs#1897 but for "enter" key.

There are also `<delete>` and `<backspace>` bindings which behave differently in the terminal, but I'm not sure which key code should be used.

I'll submit the same patch to the original evil-org-mode repo.