### PR TITLE
Fixed :wq in Org Src

### DIFF
--- a/evil-org.el
+++ b/evil-org.el
@@ -907,6 +907,7 @@ Optional argument THEME list of themes. See evil-org-keytheme for a list of valu
   (define-key org-capture-mode-map [remap evil-quit]                    #'org-capture-kill))
 
 (with-eval-after-load 'org-src
+  (define-key org-src-mode-map [remap evil-write]                   #'org-edit-src-save)
   (define-key org-src-mode-map [remap evil-save-and-close]          #'evil-org-edit-src-exit)
   (define-key org-src-mode-map [remap evil-save-modified-and-close] #'evil-org-edit-src-exit)
   (define-key org-src-mode-map [remap evil-quit]                    #'org-edit-src-abort))

--- a/evil-org.el
+++ b/evil-org.el
@@ -895,9 +895,9 @@ Optional argument THEME list of themes. See evil-org-keytheme for a list of valu
      evil-org-mode-map)))
 
 (defun evil-org-edit-src-exit ()
-  "Save then `evil-edit-src-exit'."
+  "Save with `org-edit-src-save', then `evil-edit-src-exit'."
   (interactive)
-  (mapc #'call-interactively '(evil-write org-edit-src-exit)))
+  (mapc #'call-interactively '(org-edit-src-save org-edit-src-exit)))
 
 ;;; vim-like confirm/abort for capture and src
 ;;; Taken from mwillsey (Max Willsey) on https://github.com/syl20bnr/spacemacs/pull/7400


### PR DESCRIPTION
`:wq` command (and `:w`) currently fails in an `Org Src` buffer.

It is currently mapped to the  `evil-org-edit-src-exit` function. This function uses `evil-write`.

`evil-write` tries to save the `Org Src` buffer to a new file instead of embedding the buffer into the parent org file. The actual desired behavior is provided by `org-edit-src-save`.

- Changed the `evil-org-edit-src-exit` function to use `org-edit-src-save` instead.
- Set function for `:w` to `org-edit-src-save`