### PR TITLE
merge most changes from upstream evil-org-mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -159,8 +159,10 @@ See [[file:doc/changelog.org][changelog]] for a history of changes.
     (use-package evil-org
       :ensure t
       :after org
-      :hook (org-mode . evil-org-mode)
+      :hook ((org-mode . evil-org-mode)
+             (org-agenda-mode . evil-org-agenda-mode))
       :config
+      (evil-org-set-key-theme)
       (require 'evil-org-agenda)
       (evil-org-agenda-set-keys))
     #+END_SRC

--- a/README.org
+++ b/README.org
@@ -10,6 +10,7 @@ From version 1.3 it was taken over by Somelauw.
 See [[file:doc/changelog.org][changelog]] for a history of changes.
 
 ** Features
+
  - normal, visual and insert mode bindings
  - key bindings organised in key themes
  - operators like > and < to work on headings
@@ -68,7 +69,7 @@ See [[file:doc/changelog.org][changelog]] for a history of changes.
      |-------------------------+-------------------------+-----------------------------------------------------------------------------------|
      | Evil key                | Emacs key               | explanation                                                                       |
      |-------------------------+-------------------------+-----------------------------------------------------------------------------------|
-     | <tab>, S-<return>       | <tab>                   | go to the corresponding entry at point                                            |
+     | TAB, S-<return>         | TAB                     | go to the corresponding entry at point                                            |
      | <return>                | <return>                | go to the Org mode file which contains the item at point                          |
      | M-<return>              | L                       | Display Org file and center around the item                                       |
      | <space>                 | <space>                 | scroll up                                                                         |
@@ -101,10 +102,10 @@ See [[file:doc/changelog.org][changelog]] for a history of changes.
      | gR                      | g                       | refresh all agendas                                                               |
      | ZQ                      | x                       | exit agenda                                                                       |
      | ZZ                      | Q                       | quit agenda                                                                       |
-     | z                       | v                       | tweak display (deadlines, diary, follow/log-mode, entry text, grid, day/week/year |
+     | gD                      | v                       | tweak display (deadlines, diary, follow/log-mode, entry text, grid, day/week/year |
      | ZD                      | #                       | dim blocked tasks                                                                 |
      | sc, sr, se, st, s^      | <, =, _, /, ^           | filter by category, regexp, effort, tag, top headline                             |
-     | su                      | \vert                   | remove all filters                                                                |
+     | S                       | \vert                   | remove all filters                                                                |
      | ss                      | ~                       | filter/limit interactively                                                        |
      | I                       | I                       | clock in                                                                          |
      | O                       | O                       | clock out                                                                         |
@@ -130,15 +131,16 @@ See [[file:doc/changelog.org][changelog]] for a history of changes.
 ** Installation
 
 *** Manual installation
+
     #+BEGIN_SRC sh
-    mkdir -p ~/.emacs.d/plugins; git clone
-    git://github.com/somelauw/evil-org.git ~/.emacs.d/plugins/evil-org
+    mkdir -p ~/.emacs.d/plugins; git clone \
+    git://github.com/somelauw/evil-org-mode.git ~/.emacs.d/plugins/evil-org-mode
     #+END_SRC
 
 **** Configuration emacs.el
 
     #+BEGIN_SRC emacs-lisp
-    (add-to-list 'load-path "~/.emacs.d/plugins/evil-org")
+    (add-to-list 'load-path "~/.emacs.d/plugins/evil-org-mode")
     (require 'evil-org)
     (add-hook 'org-mode-hook 'evil-org-mode)
     (evil-org-set-key-theme '(navigation insert textobjects additional calendar))
@@ -152,15 +154,13 @@ See [[file:doc/changelog.org][changelog]] for a history of changes.
     #+END_SRC
 
 *** Installation by use-package
+
     #+BEGIN_SRC emacs-lisp
     (use-package evil-org
       :ensure t
       :after org
+      :hook (org-mode . evil-org-mode)
       :config
-      (add-hook 'org-mode-hook 'evil-org-mode)
-      (add-hook 'evil-org-mode-hook
-                (lambda ()
-                  (evil-org-set-key-theme)))
       (require 'evil-org-agenda)
       (evil-org-agenda-set-keys))
     #+END_SRC

--- a/evil-org-agenda.el
+++ b/evil-org-agenda.el
@@ -1,4 +1,4 @@
-;;; evil-org-agenda.el --- evil keybindings for org-agenda-mode
+;;; evil-org-agenda.el --- evil keybindings for org-agenda-mode -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2012-2017 by Somelauw
 ;; Maintainer: Somelauw

--- a/evil-org-agenda.el
+++ b/evil-org-agenda.el
@@ -112,7 +112,7 @@
     (kbd "M-j") 'org-agenda-drag-line-forward
     (kbd "M-k") 'org-agenda-drag-line-backward
     (kbd "C-S-h") 'org-agenda-todo-previousset ; Original binding "C-S-<left>"
-    (kbd "C-S-l") 'org-agenda-todo-nextset     ; Original binding "C-S-<right>"
+    (kbd "C-S-l") 'org-agenda-todo-nextset ; Original binding "C-S-<right>"
 
     ;; undo
     "u" 'org-agenda-undo
@@ -169,14 +169,14 @@
     "S" 'org-agenda-filter-remove-all
 
     ;; clock
-    "I" 'org-agenda-clock-in            ; Original binding
-    "O" 'org-agenda-clock-out           ; Original binding
+    "I" 'org-agenda-clock-in ; Original binding
+    "O" 'org-agenda-clock-out ; Original binding
     "cg" 'org-agenda-clock-goto
     "cc" 'org-agenda-clock-cancel
     "cr" 'org-agenda-clockreport-mode
 
     ;; go and show
-    "." 'org-agenda-goto-today          ; TODO: What about evil-repeat?
+    "." 'org-agenda-goto-today ; TODO: What about evil-repeat?
     "gc" 'org-agenda-goto-calendar
     "gC" 'org-agenda-convert-date
     "gd" 'org-agenda-goto-date

--- a/evil-org-agenda.el
+++ b/evil-org-agenda.el
@@ -66,7 +66,7 @@
            (call-interactively target)))))
 
 (defun evil-org-agenda-set-keys ()
-  "Set motion state keys for `org-agenda'."
+  "Set motion state keys for ‘org-agenda’."
   (evil-set-initial-state 'org-agenda-mode 'motion)
 
   ;; Horizontal movements have little use, thus we can override "f" and "t".
@@ -95,8 +95,8 @@
     "gk" 'org-agenda-previous-item
     (kbd "C-j") 'org-agenda-next-item
     (kbd "C-k") 'org-agenda-previous-item
-    (kbd "[") 'org-agenda-earlier
-    (kbd "]") 'org-agenda-later
+    (kbd "[[") 'org-agenda-earlier
+    (kbd "]]") 'org-agenda-later
     "0" 'evil-org-agenda-digit-argument-or-evil-beginning-of-line
 
     ;; manipulation
@@ -112,7 +112,7 @@
     (kbd "M-j") 'org-agenda-drag-line-forward
     (kbd "M-k") 'org-agenda-drag-line-backward
     (kbd "C-S-h") 'org-agenda-todo-previousset ; Original binding "C-S-<left>"
-    (kbd "C-S-l") 'org-agenda-todo-nextset ; Original binding "C-S-<right>"
+    (kbd "C-S-l") 'org-agenda-todo-nextset     ; Original binding "C-S-<right>"
 
     ;; undo
     "u" 'org-agenda-undo
@@ -134,7 +134,7 @@
     "~" 'org-agenda-bulk-toggle-all
     "*" 'org-agenda-bulk-mark-all
     "%" 'org-agenda-bulk-mark-regexp
-    "M" 'org-agenda-bulk-remove-all-marks
+    "M" 'org-agenda-bulk-unmark-all
     "x" 'org-agenda-bulk-action
 
     ;; refresh
@@ -156,7 +156,7 @@
     ;; 'org-agenda-day-view
     ;; 'org-agenda-week-view
     ;; 'org-agenda-year-view
-    "z" 'org-agenda-view-mode-dispatch
+    "gD" 'org-agenda-view-mode-dispatch
     "ZD" 'org-agenda-dim-blocked-tasks
 
     ;; filter
@@ -169,14 +169,14 @@
     "S" 'org-agenda-filter-remove-all
 
     ;; clock
-    "I" 'org-agenda-clock-in ; Original binding
-    "O" 'org-agenda-clock-out ; Original binding
+    "I" 'org-agenda-clock-in            ; Original binding
+    "O" 'org-agenda-clock-out           ; Original binding
     "cg" 'org-agenda-clock-goto
     "cc" 'org-agenda-clock-cancel
     "cr" 'org-agenda-clockreport-mode
 
     ;; go and show
-    "." 'org-agenda-goto-today ; TODO: What about evil-repeat?
+    "." 'org-agenda-goto-today          ; TODO: What about evil-repeat?
     "gc" 'org-agenda-goto-calendar
     "gC" 'org-agenda-convert-date
     "gd" 'org-agenda-goto-date

--- a/evil-org-agenda.el
+++ b/evil-org-agenda.el
@@ -66,7 +66,7 @@
            (call-interactively target)))))
 
 (defun evil-org-agenda-set-keys ()
-  "Set motion state keys for ‘org-agenda’."
+  "Set motion state keys for `org-agenda'."
   (evil-set-initial-state 'org-agenda-mode 'motion)
 
   ;; Horizontal movements have little use, thus we can override "f" and "t".

--- a/evil-org-test.el
+++ b/evil-org-test.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: t -*-
 (require 'evil-org)
 (require 'ert)
 

--- a/evil-org-test.el
+++ b/evil-org-test.el
@@ -120,7 +120,7 @@
                  (evil-org-with
                   "* |Funny heading with some text                                     :testcase:"
                   (let ((w (evil-a-word)))
-                    (evil-org-delete (car w) (cdr w)))))))
+                    (evil-org-delete (cl-first w) (cl-second w)))))))
 
 ;; TODO test x and X
 ;; TODO test < and >

--- a/evil-org-test.el
+++ b/evil-org-test.el
@@ -121,7 +121,7 @@
                  (evil-org-with
                   "* |Funny heading with some text                                     :testcase:"
                   (let ((w (evil-a-word)))
-                    (evil-org-delete (cl-first w) (cl-second w)))))))
+                    (evil-org-delete (car w) (cdr w)))))))
 
 ;; TODO test x and X
 ;; TODO test < and >

--- a/evil-org.el
+++ b/evil-org.el
@@ -1,4 +1,4 @@
-;;; evil-org.el --- evil keybindings for org-mode
+;;; evil-org.el --- evil keybindings for org-mode -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2012-2017 by Somelauw
 ;; Maintainer: Somelauw

--- a/evil-org.el
+++ b/evil-org.el
@@ -8,7 +8,7 @@
 ;; Created: 2012-06-14
 ;; Forked-since: 2017-02-12
 ;; Version: 1.0.3
-;; Package-Requires: ((emacs "24.4") (evil "1.0"))
+;; Package-Requires: ((emacs "25.1") (evil "1.0"))
 ;; Keywords: evil vim-emulation org-mode key-bindings presets
 
 ;; This file is not part of GNU Emacs
@@ -36,8 +36,10 @@
 ;;
 ;;; Code:
 (eval-when-compile
-  (require 'let-alist))
+  (require 'let-alist)
+  (require 'org-capture))
 (require 'cl-lib)
+(require 'cl-seq)
 (require 'evil)
 (require 'org)
 (require 'org-element)
@@ -565,7 +567,7 @@ Argument INCOG whether to open in incognito mode."
           ;; break from outer loop when there are no more
           ;; org links
           (when (or (not (< (point) end))
-                    (not (null org-link-search-failed)))
+                    (not (null org-link--search-failed)))
             (throw 'break 0))
           (if (not (null incog))
               (evil-org-open-incognito)
@@ -891,7 +893,7 @@ Optional argument THEME list of themes. See `evil-org-key-theme' for a list of v
     (when (memq 'todo theme) (evil-org--populate-todo-bindings))
     (when (memq 'heading theme) (evil-org--populate-heading-bindings))
     (when (memq 'calendar theme) (evil-org--populate-calendar-bindings))
-    (setcdr (assq 'evil-org-mode minor-mode-map-alist evil-org-mode-map))))
+    (setcdr (assq 'evil-org-mode minor-mode-map-alist) evil-org-mode-map)))
 
 (defun evil-org-edit-src-exit ()
   "Save then `evil-edit-src-exit'."

--- a/evil-org.el
+++ b/evil-org.el
@@ -756,6 +756,7 @@ Includes tables, list items and subtrees."
                           org-insert-todo-heading-respect-content))
   (evil-define-key '(normal visual) evil-org-mode-map
     (kbd "TAB") #'org-cycle
+    (kbd "<tab>") #'org-cycle
     (kbd "<backtab>") #'org-shifttab
     (kbd "<") #'evil-org-<
     (kbd ">") #'evil-org->))

--- a/evil-org.el
+++ b/evil-org.el
@@ -54,7 +54,7 @@
       '(navigation textobjects additional calendar)
     '(navigation insert textobjects additional calendar))
   "Which key themes to enable.
-If you use this variable, you should call ‘evil-org-set-key-theme’ with zero
+If you use this variable, you should call `evil-org-set-key-theme' with zero
 arguments."
   :group 'evil-org
   :type '(set (const navigation)
@@ -86,7 +86,7 @@ This can be used by non-qwerty users who don't use hjkl."
 (defcustom evil-org-special-o/O '(table-row item)
   "When o and O should be special.
 This makes them continue item lists and table rows.
-By default, o and O are bound to ‘evil-org-open-above’ and ‘evil-org-open-below’."
+By default, o and O are bound to `evil-org-open-above' and `evil-org-open-below'."
   :group 'evil-org
   :type '(set (const table-row) (const item)))
 
@@ -98,7 +98,7 @@ By default, o and O are bound to ‘evil-org-open-above’ and ‘evil-org-open-
 (defcustom evil-org-want-hybrid-shift t
   "Whether HJKL should fall back on default bindings if not on heading/item.
 This variable only takes effect when shift keytheme is enabled and should be set
-before calling ‘evil-org-set-keytheme’."
+before calling `evil-org-set-keytheme'."
   :group 'evil-org
   :type 'boolean)
 
@@ -210,8 +210,8 @@ Optional argument ARGUMENTS arguments to pass to FUN."
   (while (org-up-heading-safe)))
 
 (evil-define-motion evil-org-end-of-line (&optional n)
-  "Like ‘org-end-of-line’ but respects ‘evil-respect-visual-line-mode’.
-makes ‘org-special-ctrl-a/e’ work as well."
+  "Like `org-end-of-line' but respects `evil-respect-visual-line-mode'.
+makes `org-special-ctrl-a/e' work as well."
   (when (and org-special-ctrl-a/e
              evil-move-cursor-back
              (not evil-move-beyond-eol)
@@ -243,7 +243,7 @@ makes ‘org-special-ctrl-a/e’ work as well."
                (save-excursion
                  (end-of-line)
                  (point))))
-          ;; If ‘end-of-line’ brings us before end of line or
+          ;; If `end-of-line' brings us before end of line or
           ;; even tags, i.e., the headline spans over multiple visual
           ;; lines, move there.
           (cond
@@ -259,8 +259,8 @@ makes ‘org-special-ctrl-a/e’ work as well."
        (t (end-of-line))))))
 
 (evil-define-motion evil-org-beginning-of-line (&optional n)
-  "Like ‘org-beginning-of-line’ but respects ‘evil-respect-visual-line-mode’.
-makes ‘org-special-ctrl-a/e’ work as well."
+  "Like `org-beginning-of-line' but respects `evil-respect-visual-line-mode'.
+makes `org-special-ctrl-a/e' work as well."
   (if (not evil-respect-visual-line-mode)
       (org-beginning-of-line n)
     (let ((origin (point))
@@ -269,7 +269,7 @@ makes ‘org-special-ctrl-a/e’ work as well."
           deactivate-mark)
       ;; First move to a visible line.
       (move-beginning-of-line n)
-      ;; ‘move-beginning-of-line’ may leave point after invisible
+      ;; `move-beginning-of-line' may leave point after invisible
       ;; characters if line starts with such of these (e.g., with
       ;; a link at column 0).  Really move to the beginning of the
       ;; current visible line.
@@ -311,7 +311,7 @@ makes ‘org-special-ctrl-a/e’ work as well."
 ;;; insertion commands
 (defun evil-org-insert-line (count)
   "Insert at beginning of line.
-If ‘org-special-ctrl-a/e’ insertion will be done after heading and item markers.
+If `org-special-ctrl-a/e' insertion will be done after heading and item markers.
 The insertion will be repeated COUNT times."
   (interactive "p")
   (if (org-at-heading-or-item-p)
@@ -323,7 +323,7 @@ The insertion will be repeated COUNT times."
 
 (defun evil-org-append-line (count)
   "Append at end of line before ellipses if present.
-If ‘org-special-ctrl-a/e’ insert before tags on headlines.
+If `org-special-ctrl-a/e' insert before tags on headlines.
 The insertion will be repeated COUNT times."
   (interactive "p")
   (if (org-at-heading-p)
@@ -336,7 +336,7 @@ The insertion will be repeated COUNT times."
 (defun evil-org-open-below (count)
   "Clever insertion of org item.
 Argument COUNT number of lines to insert.
-The behavior in items and tables can be controlled using ‘evil-org-special-o/O’.
+The behavior in items and tables can be controlled using `evil-org-special-o/O'.
 Passing in any prefix argument, executes the command without special behavior."
   (interactive "P")
   (cond ((and (memq 'table-row evil-org-special-o/O) (org-at-table-p))
@@ -344,8 +344,8 @@ Passing in any prefix argument, executes the command without special behavior."
          (evil-insert nil))
         ((and (memq 'item evil-org-special-o/O) (org-at-item-p)
               ;; Fix o/O creating new list items in the middle of nested plain
-              ;; lists. Only has an effect when ‘evil-org-special-o/O' has
-              ;; ‘item’ in it (not the default).
+              ;; lists. Only has an effect when `evil-org-special-o/O' has
+              ;; `item' in it (not the default).
               (progn (org-end-of-item)
                      (backward-char 1)
                      (evil-append nil)
@@ -361,7 +361,7 @@ Passing in any prefix argument, executes the command without special behavior."
 (defun evil-org-open-above (count)
   "Clever insertion of org item.
 Argument COUNT number of lines to insert.
-The behavior in items and tables can be controlled using ‘evil-org-special-o/O’.
+The behavior in items and tables can be controlled using `evil-org-special-o/O'.
 Passing in any prefix argument, executes the command without special behavior."
   (interactive "P")
   (cond ((and (memq 'table-row evil-org-special-o/O) (org-at-table-p))
@@ -379,10 +379,10 @@ Passing in any prefix argument, executes the command without special behavior."
                (call-interactively #'indent-according-to-mode))))))
 
 (defun evil-org-return (arg)
-  "Like ‘org-return’, but continues items and tables like ‘evil-open-below’.
+  "Like `org-return', but continues items and tables like `evil-open-below'.
 Pressing return twice cancels the continuation of the itemlist or table.
 If ARG is set it will not cancel the continuation.
-The behavior of this function can be controlled using ‘evil-org-special-o/O’."
+The behavior of this function can be controlled using `evil-org-special-o/O'."
   (interactive "P")
   (cond ((and (not arg) (evil-org--empty-element-p))
          (delete-region (line-beginning-position) (line-end-position)))
@@ -417,7 +417,7 @@ The behavior of this function can be controlled using ‘evil-org-special-o/O’
 (defmacro evil-org-define-eol-command (cmd)
   "Return a function that executes CMD at eol and then enters insert state.
 eol stands for end of line.
-For many org functions such as ‘org-insert-heading’, this creates a heading below the current line."
+For many org functions such as `org-insert-heading', this creates a heading below the current line."
   (let ((newcmd (intern (concat "evil-org-" (symbol-name cmd) "-below"))))
     `(progn
        (defun ,newcmd ()
@@ -431,7 +431,7 @@ For many org functions such as ‘org-insert-heading’, this creates a heading 
 (defmacro evil-org-define-bol-command (cmd)
   "Return a function that executes CMD at bol and then enters insert state.
 bol stands for beginning of line.
-For many org functions such as ‘org-insert-heading’, this creates a heading above the current line."
+For many org functions such as `org-insert-heading', this creates a heading above the current line."
   (let ((newcmd (intern (concat "evil-org-" (symbol-name cmd) "-above"))))
     `(progn
        (defun ,newcmd ()
@@ -876,7 +876,7 @@ Includes tables, list items and subtrees."
 
 (defun evil-org-set-key-theme (&optional theme)
   "Select what keythemes to enable.
-Optional argument THEME list of themes. See ‘evil-org-key-theme’ for a list of values."
+Optional argument THEME list of themes. See `evil-org-key-theme' for a list of values."
   (let ((theme (or theme evil-org-key-theme)))
     (setq evil-org-mode-map (make-sparse-keymap))
     (evil-org--populate-base-bindings)
@@ -893,7 +893,7 @@ Optional argument THEME list of themes. See ‘evil-org-key-theme’ for a list 
     (setcdr (assq 'evil-org-mode minor-mode-map-alist evil-org-mode-map))))
 
 (defun evil-org-edit-src-exit ()
-  "Save then ‘evil-edit-src-exit’."
+  "Save then `evil-edit-src-exit'."
   (interactive)
   (mapc #'call-interactively '(evil-write org-edit-src-exit)))
 

--- a/evil-org.el
+++ b/evil-org.el
@@ -691,7 +691,7 @@ Includes tables, list items and subtrees."
   (save-excursion
     (when beg (goto-char beg))
     (let ((element (org-element-at-point)))
-      (when (or (not (memq (cl-first element) org-element-greater-elements))
+      (when (or (not (memq (car element) org-element-greater-elements))
                 (and end (>= end (org-element-property :end element))))
         (setq element (evil-org-parent element)))
       (dotimes (_ (1- count))
@@ -705,7 +705,7 @@ Includes tables, list items and subtrees."
   (save-excursion
     (when beg (goto-char beg))
     (let ((element (org-element-at-point)))
-      (unless (memq (cl-first element) org-element-greater-elements)
+      (unless (memq (car element) org-element-greater-elements)
         (setq element (evil-org-parent element)))
       (dotimes (_ (1- count))
         (setq element (evil-org-parent element)))

--- a/evil-org.el
+++ b/evil-org.el
@@ -7,7 +7,7 @@
 ;; Git-Repository: git://github.com/Somelauw/evil-org-mode.git
 ;; Created: 2012-06-14
 ;; Forked-since: 2017-02-12
-;; Version: 1.0.2
+;; Version: 1.0.3
 ;; Package-Requires: ((emacs "24.4") (evil "1.0"))
 ;; Keywords: evil vim-emulation org-mode key-bindings presets
 
@@ -54,7 +54,7 @@
       '(navigation textobjects additional calendar)
     '(navigation insert textobjects additional calendar))
   "Which key themes to enable.
-If you use this variable, you should call `evil-org-set-key-theme' with zero
+If you use this variable, you should call ‘evil-org-set-key-theme’ with zero
 arguments."
   :group 'evil-org
   :type '(set (const navigation)
@@ -98,7 +98,7 @@ By default, o and O are bound to ‘evil-org-open-above’ and ‘evil-org-open-
 (defcustom evil-org-want-hybrid-shift t
   "Whether HJKL should fall back on default bindings if not on heading/item.
 This variable only takes effect when shift keytheme is enabled and should be set
-before calling `evil-org-set-keytheme'."
+before calling ‘evil-org-set-keytheme’."
   :group 'evil-org
   :type 'boolean)
 
@@ -125,7 +125,7 @@ before calling `evil-org-set-keytheme'."
   "Go to end of line and call provided function.
 FUN function callback
 Optional argument ARGUMENTS arguments to pass to FUN."
-  (obsolete 'evil-org-define-bol-command "0.9.4")
+  (declare (obsolete 'evil-org-define-eol-command "0.9.4"))
   (end-of-visible-line)
   (apply fun arguments)
   (evil-insert nil))
@@ -134,7 +134,7 @@ Optional argument ARGUMENTS arguments to pass to FUN."
   "Go to beginning of line and call provided function.
 FUN function callback
 Optional argument ARGUMENTS arguments to pass to FUN."
-  (obsolete 'evil-org-define-bol-command "0.9.4")
+  (declare (obsolete 'evil-org-define-bol-command "0.9.4"))
   (beginning-of-line)
   (apply fun arguments)
   (evil-insert nil))
@@ -210,8 +210,8 @@ Optional argument ARGUMENTS arguments to pass to FUN."
   (while (org-up-heading-safe)))
 
 (evil-define-motion evil-org-end-of-line (&optional n)
-  "Like `org-end-of-line' but respects `evil-respect-visual-line-mode'.
-makes `org-special-ctrl-a/e' work as well."
+  "Like ‘org-end-of-line’ but respects ‘evil-respect-visual-line-mode’.
+makes ‘org-special-ctrl-a/e’ work as well."
   (when (and org-special-ctrl-a/e
              evil-move-cursor-back
              (not evil-move-beyond-eol)
@@ -243,7 +243,7 @@ makes `org-special-ctrl-a/e' work as well."
                (save-excursion
                  (end-of-line)
                  (point))))
-          ;; If `end-of-line' brings us before end of line or
+          ;; If ‘end-of-line’ brings us before end of line or
           ;; even tags, i.e., the headline spans over multiple visual
           ;; lines, move there.
           (cond
@@ -259,8 +259,8 @@ makes `org-special-ctrl-a/e' work as well."
        (t (end-of-line))))))
 
 (evil-define-motion evil-org-beginning-of-line (&optional n)
-  "Like `org-beginning-of-line' but respects `evil-respect-visual-line-mode'.
-makes `org-special-ctrl-a/e' work as well."
+  "Like ‘org-beginning-of-line’ but respects ‘evil-respect-visual-line-mode’.
+makes ‘org-special-ctrl-a/e’ work as well."
   (if (not evil-respect-visual-line-mode)
       (org-beginning-of-line n)
     (let ((origin (point))
@@ -269,7 +269,7 @@ makes `org-special-ctrl-a/e' work as well."
           deactivate-mark)
       ;; First move to a visible line.
       (move-beginning-of-line n)
-      ;; `move-beginning-of-line' may leave point after invisible
+      ;; ‘move-beginning-of-line’ may leave point after invisible
       ;; characters if line starts with such of these (e.g., with
       ;; a link at column 0).  Really move to the beginning of the
       ;; current visible line.
@@ -344,8 +344,8 @@ Passing in any prefix argument, executes the command without special behavior."
          (evil-insert nil))
         ((and (memq 'item evil-org-special-o/O) (org-at-item-p)
               ;; Fix o/O creating new list items in the middle of nested plain
-              ;; lists. Only has an effect when `evil-org-special-o/O' has
-              ;; `item' in it (not the default).
+              ;; lists. Only has an effect when ‘evil-org-special-o/O' has
+              ;; ‘item’ in it (not the default).
               (progn (org-end-of-item)
                      (backward-char 1)
                      (evil-append nil)
@@ -379,10 +379,10 @@ Passing in any prefix argument, executes the command without special behavior."
                (call-interactively #'indent-according-to-mode))))))
 
 (defun evil-org-return (arg)
-  "Like `org-return', but continues items and tables like `evil-open-below'.
+  "Like ‘org-return’, but continues items and tables like ‘evil-open-below’.
 Pressing return twice cancels the continuation of the itemlist or table.
 If ARG is set it will not cancel the continuation.
-The behavior of this function can be controlled using `evil-org-special-o/O’."
+The behavior of this function can be controlled using ‘evil-org-special-o/O’."
   (interactive "P")
   (cond ((and (not arg) (evil-org--empty-element-p))
          (delete-region (line-beginning-position) (line-end-position)))
@@ -400,7 +400,7 @@ The behavior of this function can be controlled using `evil-org-special-o/O’."
                 (row (nth (1- (org-table-current-line)) rows)))
            (cl-every 'string-empty-p row)))
         ((org-at-item-p)
-         (string-match-p "^[[:space:]]*\\([+-]\\|[1-9]+\\.\\)[[:space:]]*\\(::[[:space:]]*\\)?$"
+         (string-match-p "^[[:space:]]*\\([+-]\\|[[:digit:]]+[.)]\\)[[:space:]]*\\(::[[:space:]]*\\)?$"
                          (thing-at-point 'line)))))
 
 ;; other
@@ -417,7 +417,7 @@ The behavior of this function can be controlled using `evil-org-special-o/O’."
 (defmacro evil-org-define-eol-command (cmd)
   "Return a function that executes CMD at eol and then enters insert state.
 eol stands for end of line.
-For many org functions such as `org-insert-heading', this creates a heading below the current line."
+For many org functions such as ‘org-insert-heading’, this creates a heading below the current line."
   (let ((newcmd (intern (concat "evil-org-" (symbol-name cmd) "-below"))))
     `(progn
        (defun ,newcmd ()
@@ -431,7 +431,7 @@ For many org functions such as `org-insert-heading', this creates a heading belo
 (defmacro evil-org-define-bol-command (cmd)
   "Return a function that executes CMD at bol and then enters insert state.
 bol stands for beginning of line.
-For many org functions such as `org-insert-heading', this creates a heading above the current line."
+For many org functions such as ‘org-insert-heading’, this creates a heading above the current line."
   (let ((newcmd (intern (concat "evil-org-" (symbol-name cmd) "-above"))))
     `(progn
        (defun ,newcmd ()
@@ -514,7 +514,7 @@ Argument END, second column
 If ARG > 0, move column BEG to END.
 If ARG < 0, move column END to BEG"
   (let* ((text (buffer-substring beg end))
-         (n-cells-selected (max 1 (count ?| text)))
+         (n-cells-selected (max 1 (cl-count ?| text)))
          (n-columns-to-move (* n-cells-selected (abs arg)))
          (move-left-p (< arg 0)))
     (goto-char (if move-left-p end beg))
@@ -691,7 +691,7 @@ Includes tables, list items and subtrees."
   (save-excursion
     (when beg (goto-char beg))
     (let ((element (org-element-at-point)))
-      (when (or (not (memq (car element) org-element-greater-elements))
+      (when (or (not (memq (cl-first element) org-element-greater-elements))
                 (and end (>= end (org-element-property :end element))))
         (setq element (evil-org-parent element)))
       (dotimes (_ (1- count))
@@ -705,7 +705,7 @@ Includes tables, list items and subtrees."
   (save-excursion
     (when beg (goto-char beg))
     (let ((element (org-element-at-point)))
-      (unless (memq (car element) org-element-greater-elements)
+      (unless (memq (cl-first element) org-element-greater-elements)
         (setq element (evil-org-parent element)))
       (dotimes (_ (1- count))
         (setq element (evil-org-parent element)))
@@ -736,6 +736,7 @@ Includes tables, list items and subtrees."
 (defun evil-org--populate-base-bindings ()
   "Bindings that are always available."
   (evil-define-key 'motion evil-org-mode-map
+    (kbd "0") #'evil-org-beginning-of-line
     (kbd "$") #'evil-org-end-of-line
     (kbd ")") #'evil-org-forward-sentence
     (kbd "(") #'evil-org-backward-sentence
@@ -755,8 +756,7 @@ Includes tables, list items and subtrees."
                           org-insert-todo-heading-respect-content))
   (evil-define-key '(normal visual) evil-org-mode-map
     (kbd "TAB") #'org-cycle
-    (kbd "<tab>") #'org-cycle
-    (kbd "<S-tab>") #'org-shifttab
+    (kbd "<backtab>") #'org-shifttab
     (kbd "<") #'evil-org-<
     (kbd ">") #'evil-org->))
 
@@ -812,10 +812,10 @@ Includes tables, list items and subtrees."
   "Shift bindings that conflict with evil bindings."
   (let-alist evil-org-movement-bindings
     (evil-define-key 'normal evil-org-mode-map
-      (capitalize .left) 'org-shiftleft
-      (capitalize .right) 'org-shiftright
-      (capitalize .down) 'org-shiftdown
-      (capitalize .up) 'org-shiftup)
+      (capitalize .left) #'org-shiftleft
+      (capitalize .right) #'org-shiftright
+      (capitalize .down) #'org-shiftdown
+      (capitalize .up) #'org-shiftup)
 
     ;; Make shift keys fall back on the keys they have replaced
     (when evil-org-want-hybrid-shift
@@ -876,7 +876,7 @@ Includes tables, list items and subtrees."
 
 (defun evil-org-set-key-theme (&optional theme)
   "Select what keythemes to enable.
-Optional argument THEME list of themes. See evil-org-keytheme for a list of values."
+Optional argument THEME list of themes. See ‘evil-org-key-theme’ for a list of values."
   (let ((theme (or theme evil-org-key-theme)))
     (setq evil-org-mode-map (make-sparse-keymap))
     (evil-org--populate-base-bindings)
@@ -890,12 +890,10 @@ Optional argument THEME list of themes. See evil-org-keytheme for a list of valu
     (when (memq 'todo theme) (evil-org--populate-todo-bindings))
     (when (memq 'heading theme) (evil-org--populate-heading-bindings))
     (when (memq 'calendar theme) (evil-org--populate-calendar-bindings))
-    (setcdr
-     (assq 'evil-org-mode minor-mode-map-alist)
-     evil-org-mode-map)))
+    (setcdr (assq 'evil-org-mode minor-mode-map-alist evil-org-mode-map))))
 
 (defun evil-org-edit-src-exit ()
-  "Save then `evil-edit-src-exit'."
+  "Save then ‘evil-edit-src-exit’."
   (interactive)
   (mapc #'call-interactively '(evil-write org-edit-src-exit)))
 


### PR DESCRIPTION
I curated the changes from upstream evil-org-mode I wanted merged into Doom's fork of Evil Org mode. Probably the most important ones are in `evil-org-agenda` since the `org-agenda-bulk-remove-all-marks` command was removed and this PR brings those keybindings up to date with Doom's keybinding conventions.